### PR TITLE
update pytaco installation instructions

### DIFF
--- a/docs/tutorial/index.html
+++ b/docs/tutorial/index.html
@@ -162,7 +162,7 @@
 <li>Install <a href="https://www.python.org/downloads/">Python 3</a>. </li>
 <li>Intall <a href="https://jupyter.org/install">Jupyter</a>.</li>
 <li>Install <a href="https://scipy.org/install.html">NumPy and SciPy</a>.</li>
-<li>Install <a href="https://github.com/tensor-compiler/taco/tree/second-taco">PyTaco</a>. Be sure to clone the <code>second-taco</code> branch. </li>
+<li>Install <a href="https://github.com/tensor-compiler/taco/">PyTaco</a>. Follow the instructions to build taco with the Python API.</li>
 <li>Clone the repository with the <a href="https://github.com/tensor-compiler/taco-jupyter-notebooks">tutorials</a>. </li>
 </ol>
               


### PR DESCRIPTION
The tutorial page I wrote before linked to the second-taco branch, which no longer exists, so I updated the link and the corresponding instruction. 